### PR TITLE
změna odkazování na repozitář

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -21,7 +21,7 @@ footer-links:
   email:
   facebook:
   flickr:
-  github: barryclark/jekyll-now
+  github: 450000/450000.github.io
   instagram:
   linkedin:
   pinterest:


### PR DESCRIPTION
Dole na stránce bylo odkazováno na repozitář barryclark/jekyll-now , tak jsem to předělala na 450000/450000.github.io
